### PR TITLE
Increased stack size for CD ROM reading thread

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ INCLUDES	:= \
 
 
 CFLAGS	= \
-  -g -O2 $(MACHDEP) $(INCLUDE) -DHAVE_CONFIG_H -DHAVE_FLOAT_H -DMEM2 -fno-strict-overflow -fsigned-char \
+  -g -O3 $(MACHDEP) $(INCLUDE) -DHAVE_CONFIG_H -DHAVE_FLOAT_H -DMEM2 -fno-strict-overflow -fsigned-char \
   -Winline \
   -fomit-frame-pointer \
   --param large-function-growth=800 \

--- a/mednafen/src/cdrom/cdromfile.cpp
+++ b/mednafen/src/cdrom/cdromfile.cpp
@@ -95,8 +95,10 @@ struct CDRFile
 };
 
 
+#ifndef WII
 // 1-bit per sector on the physical CD.  If set, don't read that sector.
 static uint8 SkipSectorRead[65536];
+#endif
 
 // lookup table for crc calculation
 static uint16 subq_crctab[256] = 

--- a/mednafen/src/cdrom/cdromif.cpp
+++ b/mednafen/src/cdrom/cdromif.cpp
@@ -290,6 +290,11 @@ void *ReadThreadStart(void *arg)
 #endif
 }
 
+#ifdef WII
+#define CDR_STACK_SIZE 32*1024
+static u8 *_cdr_stack[CDR_STACK_SIZE] ATTRIBUTE_ALIGN(8);
+#endif
+
 bool CDIF_Open(const char *device_name)
 {
  CDIF_Message msg;
@@ -308,7 +313,8 @@ bool CDIF_Open(const char *device_name)
 #ifndef WII
  CDReadThread = MDFND_CreateThread(ReadThreadStart, device_name ? strdup(device_name) : NULL);
 #else
-  LWP_CreateThread(&CDReadThread, ReadThreadStart, device_name ? strdup(device_name) : NULL, 0, 0, 80);
+  LWP_CreateThread(&CDReadThread, ReadThreadStart, 
+    device_name ? strdup(device_name) : NULL, _cdr_stack, CDR_STACK_SIZE, 80);
 #endif
 
  EmuThreadQueue->Read(&msg);


### PR DESCRIPTION
Appears to fix crash issues (#69) with latest libogc